### PR TITLE
Check for Pre-Java 9 or Java 9 added to script to prevent it from excepting and falling over (Linux and MacOSX only)

### DIFF
--- a/template-for-recording/record_screen_and_upload.sh
+++ b/template-for-recording/record_screen_and_upload.sh
@@ -167,5 +167,16 @@ PARAM_CONFIG_FILE="--config ${APP_HOME}/config/credentials.config"
 PARAM_STORE_DIR="--store ${APP_HOME}/record/localstore"
 PARAM_SOURCECODE_DIR="--sourcecode ${APP_HOME}"
 
+JAVA_VERSION=$($JAVACMD -version 2>&1 | grep '"9\|"10\|"11\|"12')
+if [ -z "${JAVA_VERSION}" ]; then
+   echo "---> Pre-Java 9 detected <---"
+   echo "Using DEFAULT_JVM_OPTS variable with value '${DEFAULT_JVM_OPTS}'"
+else
+   echo "---> Java 9 or higher detected ($JAVA_VERSION) <---"
+   DEFAULT_JVM_OPTS="--illegal-access=warn  --add-modules=java.xml.bind,java.activation  ${DEFAULT_JVM_OPTS}"
+   echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '${DEFAULT_JVM_OPTS}'"
+   echo "--------------------------------------------------------------------------------------------------------------"
+fi
+
 eval splitJvmOpts ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} ${RECORD_OPTS}
 exec "$JAVACMD" "${JVM_OPTS[@]}" -jar "$JARFILE" ${PARAM_CONFIG_FILE} ${PARAM_STORE_DIR} ${PARAM_SOURCECODE_DIR} "$@"


### PR DESCRIPTION
I have tested this on Linux for both Java 8 and 9. Could you please check if this works on the MacOSX, in theory, it should work. Maybe also check for Linux just for double assurance.