### PR TITLE
Amend windows batch script to pre java 9 and java 9

### DIFF
--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -74,13 +74,21 @@ set PARAM_CONFIG_FILE=--config %APP_HOME%\config\credentials.config
 set PARAM_STORE_DIR=--store %APP_HOME%\record\localstore
 set PARAM_SOURCECODE_DIR=--sourcecode %APP_HOME%
 
-set JAVA_VERSION=(%JAVA_EXE% -version 2^>^&1 ^| findstr /i '"9\|"10\|"11\|"12')
-if "%JAVA_VERSION%"=="" (
+for /f "tokens=3" %%g in ('%JAVA_EXE% -version 2^>^&1 ^| findstr /i "version"') do (
+    set JAVA_FULL_VERSION=%%g
+)
+set JAVA_FULL_VERSION=%JAVA_FULL_VERSION:"=%
+
+for /f "delims=. tokens=1-3" %%v in ("%JAVA_FULL_VERSION%") do (
+    set JAVA_VERSION=%%v
+)
+
+if "%JAVA_VERSION%" LSS "9" (
    echo "---> Pre-Java 9 detected <---"
    echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
 ) else (
-   echo "---> Java 9 or higher detected (%JAVA_VERSION%) <---"
-   set DEFAULT_JVM_OPTS="--illegal-access=warn  --add-modules=java.xml.bind,java.activation  %DEFAULT_JVM_OPTS%"
+   echo "---> Java 9 or higher detected (Java version %JAVA_VERSION%) <---"
+   set DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%
    echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
    echo "--------------------------------------------------------------------------------------------------------------"
 )

--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -74,6 +74,16 @@ set PARAM_CONFIG_FILE=--config %APP_HOME%\config\credentials.config
 set PARAM_STORE_DIR=--store %APP_HOME%\record\localstore
 set PARAM_SOURCECODE_DIR=--sourcecode %APP_HOME%
 
+set JAVA_VERSION=(%JAVA_EXE% -version 2^>^&1 ^| findstr /i '"9\|"10\|"11\|"12')
+if "%JAVA_VERSION%"=="" (
+   echo "---> Pre-Java 9 detected <---"
+   echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
+) else (
+   echo "---> Java 9 or higher detected (%JAVA_VERSION%) <---"
+   set DEFAULT_JVM_OPTS="--illegal-access=warn  --add-modules=java.xml.bind,java.activation  %DEFAULT_JVM_OPTS%"
+   echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
+   echo "--------------------------------------------------------------------------------------------------------------"
+)
 
 @rem Execute Record
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %RECORD_OPTS% -jar "%JARFILE%" %PARAM_CONFIG_FILE% %PARAM_STORE_DIR% %PARAM_SOURCECODE_DIR% %CMD_LINE_ARGS%


### PR DESCRIPTION
Has been tested on Windows, some feedback of output attached.

Please do try it out on your own Windows environment - slightly less confident how different versions of Windows will react to this script.

[windows_output_logs.txt](https://github.com/julianghionoiu/tdl-lord-of-runners/files/1547827/windows_output_logs.txt)

Error occurred not related to the batch script changes:
```
ERROR [VideoRec]   - FfmpegException::make(finalStr): could not open codec: Error number -1 occurred (-1) (VideoExceptions.cpp:118)
Exception in thread "VideoRec" java.lang.RuntimeException: could not open codec: Error number -1 occurred (-1)
        at io.humble.video.VideoJNI.Encoder_open(Native Method)
        at io.humble.video.Encoder.open(Encoder.java:154)
        at tdl.record.screen.video.VideoRecorder.open(VideoRecorder.java:118)
        at tdl.record_upload.VideoRecordingThread.run(VideoRecordingThread.java:35)
```