### PR TITLE
Fix windows batch script to pre java 9 and java 9

### DIFF
--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -36,8 +36,8 @@ echo location of your Java installation.
 goto fail
 
 :findJavaFromJavaHome
-set "JAVA_HOME=%JAVA_HOME:"=%
-set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%\bin\java.exe
 
 echo.
 echo JAVA_HOME=%JAVA_HOME%
@@ -87,13 +87,13 @@ set PARAM_SOURCECODE_DIR=--sourcecode %APP_HOME%
 for /f "tokens=3" %%g in ('%JAVA_EXE% -version 2^>^&1 ^| findstr /i "version"') do (
     set JAVA_FULL_VERSION=%%g
 )
-set "JAVA_FULL_VERSION=%JAVA_FULL_VERSION:"=%
+set JAVA_FULL_VERSION=%JAVA_FULL_VERSION:"=%
 
 echo.
 echo JAVA_FULL_VERSION=%JAVA_FULL_VERSION%
 
 for /f "delims=. tokens=1-3" %%v in ("%JAVA_FULL_VERSION%") do (
-    if "%%v" LSS "9" (
+    if "%%v" == "1" (
     	set JAVA_VERSION=%%w
     ) else (
     	set JAVA_VERSION=%%v
@@ -105,12 +105,12 @@ echo JAVA_VERSION=%JAVA_VERSION%
 
 if "%JAVA_VERSION%" LSS "9" (
    echo "--- Pre-Java 9 detected (Java version %JAVA_VERSION%) ---"
-   echo Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'
+   echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
 ) else (
    echo "--- Java 9 or higher detected (Java version %JAVA_VERSION%) ---"
-   set "DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%"
+   set DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%
    echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
-   echo --------------------------------------------------------------------------------------------------------------
+   echo "--------------------------------------------------------------------------------------------------------------"
 )
 
 @echo on

--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -5,6 +5,10 @@
 @rem
 @rem ##########################################################################
 
+echo.
+echo "Displaying operating system specific systeminfo..."
+systeminfo | findstr /C:"OS"
+
 @rem Set local scope for the variables with windows NT shell
 if "%OS%"=="Windows_NT" setlocal
 
@@ -32,8 +36,14 @@ echo location of your Java installation.
 goto fail
 
 :findJavaFromJavaHome
-set JAVA_HOME=%JAVA_HOME:"=%
+set "JAVA_HOME=%JAVA_HOME:"=%
 set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+echo.
+echo JAVA_HOME=%JAVA_HOME%
+
+echo.
+echo JAVA_EXE=%JAVA_EXE%
 
 if exist "%JAVA_EXE%" goto init
 
@@ -77,24 +87,33 @@ set PARAM_SOURCECODE_DIR=--sourcecode %APP_HOME%
 for /f "tokens=3" %%g in ('%JAVA_EXE% -version 2^>^&1 ^| findstr /i "version"') do (
     set JAVA_FULL_VERSION=%%g
 )
-set JAVA_FULL_VERSION=%JAVA_FULL_VERSION:"=%
+set "JAVA_FULL_VERSION=%JAVA_FULL_VERSION:"=%
+
+echo.
+echo JAVA_FULL_VERSION=%JAVA_FULL_VERSION%
 
 for /f "delims=. tokens=1-3" %%v in ("%JAVA_FULL_VERSION%") do (
     set JAVA_VERSION=%%v
 )
 
+echo.
+echo JAVA_VERSION=%JAVA_VERSION%
+
 if "%JAVA_VERSION%" LSS "9" (
-   echo "---> Pre-Java 9 detected <---"
-   echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
+   echo "--- Pre-Java 9 detected ---"
+   echo Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'
 ) else (
-   echo "---> Java 9 or higher detected (Java version %JAVA_VERSION%) <---"
-   set DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%
+   echo "--- Java 9 or higher detected (Java version %JAVA_VERSION%) ---"
+   set "DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%"
+   echo DEFAULT_JVM_OPTS=%DEFAULT_JVM_OPTS%
    echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
-   echo "--------------------------------------------------------------------------------------------------------------"
+   echo --------------------------------------------------------------------------------------------------------------
 )
 
+@echo on
 @rem Execute Record
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %RECORD_OPTS% -jar "%JARFILE%" %PARAM_CONFIG_FILE% %PARAM_STORE_DIR% %PARAM_SOURCECODE_DIR% %CMD_LINE_ARGS%
+@echo off
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -6,7 +6,7 @@
 @rem ##########################################################################
 
 echo.
-echo "Displaying operating system specific systeminfo..."
+echo Displaying operating system specific systeminfo...
 systeminfo | findstr /C:"OS"
 
 @rem Set local scope for the variables with windows NT shell
@@ -105,7 +105,6 @@ if "%JAVA_VERSION%" LSS "9" (
 ) else (
    echo "--- Java 9 or higher detected (Java version %JAVA_VERSION%) ---"
    set "DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%"
-   echo DEFAULT_JVM_OPTS=%DEFAULT_JVM_OPTS%
    echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
    echo --------------------------------------------------------------------------------------------------------------
 )

--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -93,14 +93,18 @@ echo.
 echo JAVA_FULL_VERSION=%JAVA_FULL_VERSION%
 
 for /f "delims=. tokens=1-3" %%v in ("%JAVA_FULL_VERSION%") do (
-    set JAVA_VERSION=%%v
+    if "%%v" LSS "9" (
+    	set JAVA_VERSION=%%w
+    ) else (
+    	set JAVA_VERSION=%%v
+    )
 )
 
 echo.
 echo JAVA_VERSION=%JAVA_VERSION%
 
 if "%JAVA_VERSION%" LSS "9" (
-   echo "--- Pre-Java 9 detected ---"
+   echo "--- Pre-Java 9 detected (Java version %JAVA_VERSION%) ---"
    echo Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'
 ) else (
    echo "--- Java 9 or higher detected (Java version %JAVA_VERSION%) ---"


### PR DESCRIPTION
On the back of the conversation about Windows batch script failing for the recording program.

Added echoes displaying system info and important environment variables and removed reserved characters like `>` and `<` from echoes. <=== these were causing the error '..specified file cannot be found'

Also fixed two usages of the set variable statements for `JAVA_HOME` and `JAVA_FULL_VERSION` <=== this is what the user had as an issue and the other implementation of `set` it `set "VARIABLE=VALUE"` surrounded by quotes.

Here's a snapshot of the run logs:
```

Displaying operating system specific systeminfo...
OS Name:                   Microsoft Windows 10 Enterprise Evaluation
OS Version:                10.0.15063 N/A Build 15063
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
BIOS Version:              innotek GmbH VirtualBox, 12/1/2006

JAVA_FULL_VERSION=9.0.1

JAVA_VERSION=9
"--- Java 9 or higher detected (Java version 9) ---"
"Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to ''"
--------------------------------------------------------------------------------------------------------------

C:\Users\IEUser\Downloads\tdl-lord-of-runners\template-for-recording>"java.exe" --illegal-access=warn --add-modules=java.xml.bind,java.activation    -jar "C:\Users\IEUser\Downloads\tdl-lord-of-runners\template-for-recording\\record\record-and-upload-capsule.jar" --config C:\Users\IEUser\Downloads\tdl-lord-of-runners\template-for-recording\\config\credentials.config --store C:\Users\IEUser\Downloads\tdl-lord-of-runners\template-for-recording\\record\localstore --sourcecode C:\Users\IEUser\Downloads\tdl-lord-of-runners\template-for-recording\
WARNING: Illegal reflective access by Capsule (file:/C:/Users/IEUser/Downloads/tdl-lord-of-runners/template-for-recording/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
ERROR [main]       - User does not have enough permissions to upload. Reason: The provided token has expired. (Service: Amazon S3; Status Code: 400; Error Code: ExpiredToken; Request ID: 012B90623F1A3A91)
```