### PR TITLE
Fix java version 12 version string parsing

### DIFF
--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -137,15 +137,20 @@ for /f "delims=. tokens=1-3" %%v in ("%JAVA_FULL_VERSION%") do (
     )
 )
 
+for /f "tokens=1,2 delims=-" %%a in ("%JAVA_VERSION%") do (
+  set JAVA_VERSION=%%a
+)
+
 echo.
 echo JAVA_VERSION=%JAVA_VERSION%
+
 set JAVA_VERSION_9=9
 
 if %JAVA_VERSION% lss %JAVA_VERSION_9% (
-   echo "--- Pre-Java 9 detected (Java version %JAVA_VERSION%) ---"
+   echo "--- Pre-Java 9 detected ---"
    echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
 ) else (
-   echo "--- Java 9 or higher detected (Java version %JAVA_VERSION%) ---"
+   echo "--- Java 9 or higher detected (version %JAVA_VERSION%) ---"
    set DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%
    echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
    echo "--------------------------------------------------------------------------------------------------------------"

--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -129,6 +129,17 @@ if defined JAVA_FULL_VERSION (
 echo.
 echo JAVA_FULL_VERSION=%JAVA_FULL_VERSION%
 
+@rem Look for tokens "9, "10, "11 or "12 in the Java version string, 
+@rem if found, return the whole Java String, otherwise return empty string
+@rem
+@rem For e.g.
+@rem   --version command output    JAVA_VERSION   
+@rem   ========================   ==============
+@rem   java version "1.8.0_172"     <no output>
+@rem   java version "9.0.1"            "9
+@rem   java version "10.0.1"           "10
+@rem   java version "11.0.2"           "11
+@rem   java version "12-ea"            "12-ea
 for /f "delims=. tokens=1-3" %%v in ("%JAVA_FULL_VERSION%") do (
     if "%%v" == "1" (
     	set JAVA_VERSION=%%w
@@ -137,20 +148,37 @@ for /f "delims=. tokens=1-3" %%v in ("%JAVA_FULL_VERSION%") do (
     )
 )
 
+@rem Only include digits from value in JAVA_VERSION,
+@rem If the above value contains non-numeric values,
+@rem only the digits before it are returned
+@rem
+@rem For e.g.
+@rem   JAVA_VERSION   JAVA_VERSION_INT_VALUE   
+@rem   ============   ======================
+@rem    <no output>         <no output>
+@rem         9                  9
+@rem        10                  10
+@rem        11                  11
+@rem       12-ea                12
+@rem
+@rem The for loop below iterates through tokens, 
+@rem tokens are separated by the delimeter provided to 'delim'
+@rem Only the first token is retained, and as per the above table, 
+@rem it will always be empty or a numeric value between 9 and 12 (included)
 for /f "tokens=1,2 delims=-" %%a in ("%JAVA_VERSION%") do (
-  set JAVA_VERSION=%%a
+  set JAVA_VERSION_INT_VALUE=%%a
 )
 
 echo.
-echo JAVA_VERSION=%JAVA_VERSION%
+echo JAVA_VERSION=%JAVA_VERSION_INT_VALUE%
 
 set JAVA_VERSION_9=9
 
-if %JAVA_VERSION% lss %JAVA_VERSION_9% (
+if %JAVA_VERSION_INT_VALUE% lss %JAVA_VERSION_9% (
    echo "--- Pre-Java 9 detected ---"
    echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
 ) else (
-   echo "--- Java 9 or higher detected (version %JAVA_VERSION%) ---"
+   echo "--- Java 9 or higher detected (version %JAVA_VERSION_INT_VALUE%) ---"
    set DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%
    echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
    echo "--------------------------------------------------------------------------------------------------------------"

--- a/template-for-recording/record_screen_and_upload.sh
+++ b/template-for-recording/record_screen_and_upload.sh
@@ -168,12 +168,13 @@ PARAM_STORE_DIR="--store ${APP_HOME}/record/localstore"
 PARAM_SOURCECODE_DIR="--sourcecode ${APP_HOME}"
 
 JAVA_VERSION=$($JAVACMD -version 2>&1 | grep '"9\|"10\|"11\|"12')
+JAVA_VERSION=$(echo $JAVA_VERSION | grep -o '"[0-9]*' | tr -d '"')
 if [ -z "${JAVA_VERSION}" ]; then
    echo "---> Pre-Java 9 detected <---"
    echo "Using DEFAULT_JVM_OPTS variable with value '${DEFAULT_JVM_OPTS}'"
 else
-   echo "---> Java 9 or higher detected ($JAVA_VERSION) <---"
-   DEFAULT_JVM_OPTS="--illegal-access=warn  --add-modules=java.xml.bind,java.activation  ${DEFAULT_JVM_OPTS}"
+   echo "---> Java 9 or higher detected (version $JAVA_VERSION) <---"
+   DEFAULT_JVM_OPTS ="--illegal-access=warn  --add-modules=java.xml.bind,java.activation  ${DEFAULT_JVM_OPTS}"
    echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '${DEFAULT_JVM_OPTS}'"
    echo "--------------------------------------------------------------------------------------------------------------"
 fi

--- a/template-for-recording/record_screen_and_upload.sh
+++ b/template-for-recording/record_screen_and_upload.sh
@@ -167,13 +167,42 @@ PARAM_CONFIG_FILE="--config ${APP_HOME}/config/credentials.config"
 PARAM_STORE_DIR="--store ${APP_HOME}/record/localstore"
 PARAM_SOURCECODE_DIR="--sourcecode ${APP_HOME}"
 
+# Look for tokens "9, "10, "11 or "12 in the Java version string, 
+# if found, return the whole Java String, otherwise return empty string
+#
+# For e.g.
+#   --version command output    JAVA_VERSION   
+#   ========================   ==============
+#   java version "1.8.0_172"     <no output>
+#   java version "9.0.1"            "9
+#   java version "10.0.1"           "10
+#   java version "11.0.2"           "11
+#   java version "12-ea"            "12-ea
 JAVA_VERSION=$($JAVACMD -version 2>&1 | grep '"9\|"10\|"11\|"12')
-JAVA_VERSION=$(echo $JAVA_VERSION | grep -o '"[0-9]*' | tr -d '"')
-if [ -z "${JAVA_VERSION}" ]; then
+
+# Only include digits from value in JAVA_VERSION, 
+# If the above value contains non-numeric values, 
+# only the digits before it are returned
+#
+# For e.g.
+#   JAVA_VERSION   JAVA_VERSION_INT_VALUE   
+#   ============   ======================
+#    <no output>         <no output>
+#         9                  9
+#        10                  10
+#        11                  11
+#       12-ea                12
+#
+# The for loop below iterates through tokens, 
+# tokens are separated by the delimeter provided to 'delim'
+# Only the first token is retained, and as per the above table, 
+# it will always be empty or a numeric value between 9 and 12 (included)
+JAVA_VERSION_INT_VALUE=$(echo $JAVA_VERSION | grep -o '"[0-9]*' | tr -d '"')
+if [ -z "${JAVA_VERSION_INT_VALUE}" ]; then
    echo "---> Pre-Java 9 detected <---"
    echo "Using DEFAULT_JVM_OPTS variable with value '${DEFAULT_JVM_OPTS}'"
 else
-   echo "---> Java 9 or higher detected (version $JAVA_VERSION) <---"
+   echo "---> Java 9 or higher detected (version $JAVA_VERSION_INT_VALUE) <---"
    DEFAULT_JVM_OPTS ="--illegal-access=warn  --add-modules=java.xml.bind,java.activation  ${DEFAULT_JVM_OPTS}"
    echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '${DEFAULT_JVM_OPTS}'"
    echo "--------------------------------------------------------------------------------------------------------------"


### PR DESCRIPTION
Fixed for both Windows/MacOS and Linux, fixes #7.

Tested against version 8, 9, 10, 11 and 12 (Linux and Windows):

Some outputs for Windows:

**Java 9**
```
D:\tdl-lord-of-runners\template-for-recording>record_screen_and_upload.bat

Displaying operating system specific systeminfo...
OS Name:                   Microsoft Windows 10 Enterprise Evaluation
OS Version:                10.0.17134 N/A Build 17134
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
BIOS Version:              innotek GmbH VirtualBox, 12/1/2006

JAVA_HOME=C:\PROGRA~1\Java\JDK-90~1.4

JAVA_EXE=C:\PROGRA~1\Java\JDK-90~1.4\bin\java.exe

D:\tdl-lord-of-runners\template-for-recording>for /F "tokens=3" %g in ('C:\PROGRA~1\Java\JDK-90~1.4\bin\java.exe -version 2>&1 | findstr /i "version"') do (set JAVA_FULL_VERSION=%g )

D:\tdl-lord-of-runners\template-for-recording>(set JAVA_FULL_VERSION="9.0.4" )

JAVA_FULL_VERSION=9.0.4

JAVA_VERSION=9
"--- Java 9 or higher detected (version 9) ---"
"Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to ''"
"--------------------------------------------------------------------------------------------------------------"

D:\tdl-lord-of-runners\template-for-recording>"C:\PROGRA~1\Java\JDK-90~1.4\bin\java.exe" --illegal-access=warn --add-modules=java.xml.bind,java.activation    -jar "D:\tdl-lord-of-runners\template-for-recording\\record\record-and-upload-capsule.jar" --config D:\tdl-lord-of-runners\template-for-recording\\config\credentials.config --store D:\tdl-lord-of-runners\template-for-recording\\record\localstore --sourcecode D:\tdl-lord-of-runners\template-for-recording\
WARNING: Illegal reflective access by Capsule (file:/D:/tdl-lord-of-runners/template-for-recording/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
INFO  [main]       - Starting recording app
ERROR [main]       - Exception encountered. Stopping now.
java.lang.RuntimeException: D:\tdl-lord-of-runners\template-for-recording\config\credentials.config
        at tdl.s3.credentials.AWSSecretProperties.loadPrivateProperties(AWSSecretProperties.java:80) ~[s3-sync-stream-0.0.12.jar:na]
        at tdl.s3.credentials.AWSSecretProperties.fromPlainTextFile(AWSSecretProperties.java:33) ~[s3-sync-stream-0.0.12.jar:na]
        at tdl.record_upload.RecordAndUploadApp.main(RecordAndUploadApp.java:70) ~[record-and-upload-0.0.15.jar:na]
Caused by: java.nio.file.NoSuchFileException: D:\tdl-lord-of-runners\template-for-recording\config\credentials.config
        at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:85) ~[na:na]
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103) ~[na:na]
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108) ~[na:na]
        at java.base/sun.nio.fs.WindowsFileSystemProvider.newByteChannel(WindowsFileSystemProvider.java:231) ~[na:na]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:369) ~[na:na]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:415) ~[na:na]
        at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:384) ~[na:na]
        at java.base/java.nio.file.Files.newInputStream(Files.java:154) ~[na:na]
        at tdl.s3.credentials.AWSSecretProperties.loadPrivateProperties(AWSSecretProperties.java:76) ~[s3-sync-stream-0.0.12.jar:na]
        ... 2 common frames omitted
D:\tdl-lord-of-runners\template-for-recording>
D:\tdl-lord-of-runners\template-for-recording>set JAVA_HOME=C:\PROGRA~1\Java\JDK-12
```

**Java 10**

```
D:\tdl-lord-of-runners\template-for-recording>set JAVA_HOME=C:\PROGRA~1\Java\JDK-10.0.2

D:\tdl-lord-of-runners\template-for-recording>record_screen_and_upload.bat

Displaying operating system specific systeminfo...
OS Name:                   Microsoft Windows 10 Enterprise Evaluation
OS Version:                10.0.17134 N/A Build 17134
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
BIOS Version:              innotek GmbH VirtualBox, 12/1/2006

JAVA_HOME=C:\PROGRA~1\Java\JDK-10~1.2

JAVA_EXE=C:\PROGRA~1\Java\JDK-10~1.2\bin\java.exe

D:\tdl-lord-of-runners\template-for-recording>for /F "tokens=3" %g in ('C:\PROGRA~1\Java\JDK-10~1.2\bin\java.exe -version 2>&1 | findstr /i "version"') do (set JAVA_FULL_VERSION=%g )

D:\tdl-lord-of-runners\template-for-recording>(set JAVA_FULL_VERSION="10.0.2" )

JAVA_FULL_VERSION=10.0.2

JAVA_VERSION=10
"--- Java 9 or higher detected (version 10) ---"
"Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to ''"
"--------------------------------------------------------------------------------------------------------------"

D:\tdl-lord-of-runners\template-for-recording>"C:\PROGRA~1\Java\JDK-10~1.2\bin\java.exe" --illegal-access=warn --add-modules=java.xml.bind,java.activation    -jar "D:\tdl-lord-of-runners\template-for-recording\\record\record-and-upload-capsule.jar" --config D:\tdl-lord-of-runners\template-for-recording\\config\credentials.config --store D:\tdl-lord-of-runners\template-for-recording\\record\localstore --sourcecode D:\tdl-lord-of-runners\template-for-recording\
WARNING: Illegal reflective access by Capsule (file:/D:/tdl-lord-of-runners/template-for-recording/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
INFO  [main]       - Starting recording app
ERROR [main]       - Exception encountered. Stopping now.
java.lang.RuntimeException: D:\tdl-lord-of-runners\template-for-recording\config\credentials.config
        at tdl.s3.credentials.AWSSecretProperties.loadPrivateProperties(AWSSecretProperties.java:80) ~[s3-sync-stream-0.0.12.jar:na]
        at tdl.s3.credentials.AWSSecretProperties.fromPlainTextFile(AWSSecretProperties.java:33) ~[s3-sync-stream-0.0.12.jar:na]
        at tdl.record_upload.RecordAndUploadApp.main(RecordAndUploadApp.java:70) ~[record-and-upload-0.0.15.jar:na]
Caused by: java.nio.file.NoSuchFileException: D:\tdl-lord-of-runners\template-for-recording\config\credentials.config
        at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:85) ~[na:na]
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103) ~[na:na]
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108) ~[na:na]
        at java.base/sun.nio.fs.WindowsFileSystemProvider.newByteChannel(WindowsFileSystemProvider.java:231) ~[na:na]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:369) ~[na:na]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:415) ~[na:na]
        at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:384) ~[na:na]
        at java.base/java.nio.file.Files.newInputStream(Files.java:154) ~[na:na]
        at tdl.s3.credentials.AWSSecretProperties.loadPrivateProperties(AWSSecretProperties.java:76) ~[s3-sync-stream-0.0.12.jar:na]
        ... 2 common frames omitted
D:\tdl-lord-of-runners\template-for-recording>
```

**Java 12**
```
D:\tdl-lord-of-runners\template-for-recording>record_screen_and_upload.bat

Displaying operating system specific systeminfo...
OS Name:                   Microsoft Windows 10 Enterprise Evaluation
OS Version:                10.0.17134 N/A Build 17134
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
BIOS Version:              innotek GmbH VirtualBox, 12/1/2006

JAVA_HOME=C:\PROGRA~1\Java\jdk-12

JAVA_EXE=C:\PROGRA~1\Java\jdk-12\bin\java.exe

D:\tdl-lord-of-runners\template-for-recording>for /F "tokens=3" %g in ('C:\PROGRA~1\Java\jdk-12\bin\java.exe -version 2>&1 | findstr /i "version"') do (set JAVA_FULL_VERSION=%g )

D:\tdl-lord-of-runners\template-for-recording>(set JAVA_FULL_VERSION="12-ea" )

JAVA_FULL_VERSION=12-ea

JAVA_VERSION=12
"--- Java 9 or higher detected (version 12) ---"
"Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to ''"
"--------------------------------------------------------------------------------------------------------------"

D:\tdl-lord-of-runners\template-for-recording>"C:\PROGRA~1\Java\jdk-12\bin\java.exe" --illegal-access=warn --add-modules=java.xml.bind,java.activation    -jar "D:\tdl-lord-of-runners\template-for-recording\\record\record-and-upload-capsule.jar" --config D:\tdl-lord-of-runners\template-for-recording\\config\credentials.config --store D:\tdl-lord-of-runners\template-for-recording\\record\localstore --sourcecode D:\tdl-lord-of-runners\template-for-recording\
Error occurred during initialization of boot layer
java.lang.module.FindException: Module java.xml.bind not found
```

MacOS testing pending (change similar to Linux)