### PR TITLE
Applied fix to record_screen_and_update: Java 11 and 12 missing modules issue fix

### DIFF
--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -112,6 +112,7 @@ set PARAM_CONFIG_FILE=--config %APP_HOME%\config\credentials.config
 set PARAM_STORE_DIR=--store %APP_HOME%\record\localstore
 set PARAM_SOURCECODE_DIR=--sourcecode %APP_HOME%
 
+%JAVA_EXE% -version
 @echo on
 for /f "tokens=3" %%g in ('%JAVA_EXE% -version 2^>^&1 ^| findstr /i "version"') do (
     set JAVA_FULL_VERSION=%%g

--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -129,11 +129,11 @@ if defined JAVA_FULL_VERSION (
 echo.
 echo JAVA_FULL_VERSION=%JAVA_FULL_VERSION%
 
-@rem Look for tokens "9, "10, "11 or "12 in the Java version string, 
+@rem Look for tokens "9, "10, "11 or "12 in the Java version string,
 @rem if found, return the whole Java String, otherwise return empty string
 @rem
 @rem For e.g.
-@rem   --version command output    JAVA_VERSION   
+@rem   --version command output    JAVA_VERSION
 @rem   ========================   ==============
 @rem   java version "1.8.0_172"     <no output>
 @rem   java version "9.0.1"            "9
@@ -153,7 +153,7 @@ for /f "delims=. tokens=1-3" %%v in ("%JAVA_FULL_VERSION%") do (
 @rem only the digits before it are returned
 @rem
 @rem For e.g.
-@rem   JAVA_VERSION   JAVA_VERSION_INT_VALUE   
+@rem   JAVA_VERSION   JAVA_VERSION_INT_VALUE
 @rem   ============   ======================
 @rem    <no output>         <no output>
 @rem         9                  9
@@ -161,9 +161,9 @@ for /f "delims=. tokens=1-3" %%v in ("%JAVA_FULL_VERSION%") do (
 @rem        11                  11
 @rem       12-ea                12
 @rem
-@rem The for loop below iterates through tokens, 
+@rem The for loop below iterates through tokens,
 @rem tokens are separated by the delimeter provided to 'delim'
-@rem Only the first token is retained, and as per the above table, 
+@rem Only the first token is retained, and as per the above table,
 @rem it will always be empty or a numeric value between 9 and 12 (included)
 for /f "tokens=1,2 delims=-" %%a in ("%JAVA_VERSION%") do (
   set JAVA_VERSION_INT_VALUE=%%a
@@ -173,16 +173,22 @@ echo.
 echo JAVA_VERSION=%JAVA_VERSION_INT_VALUE%
 
 set JAVA_VERSION_9=9
+set JAVA_VERSION_11=11
 
 if %JAVA_VERSION_INT_VALUE% lss %JAVA_VERSION_9% (
    echo "--- Pre-Java 9 detected ---"
    echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
 ) else (
    echo "--- Java 9 or higher detected (version %JAVA_VERSION_INT_VALUE%) ---"
-   set DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%
-   echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
-   echo "--------------------------------------------------------------------------------------------------------------"
+   if %JAVA_VERSION_INT_VALUE% lss %JAVA_VERSION_11% (
+       set DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%
+       echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
+   ) else (
+      echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
+      echo "Not using kill-switch or modules flags starting from this version of Java"
+   )
 )
+echo "--------------------------------------------------------------------------------------------------------------"
 
 @echo on
 @rem Execute Record

--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -61,7 +61,7 @@ set JAVA_HOME=%JAVA_HOME:"=%
 @rem       %%~sI       -  expanded path contains short names only
 @rem                     (see description at https://stackoverflow.com/questions/1333589/how-do-i-transform-the-working-directory-into-a-8-3-short-file-name-using-batch?answertab=active#tab-top)
 @rem
-@rem %%..1 or %%..I in the above example, refers to the input parameter (whole string) to 'for'
+@rem %%..1 or %%..I in the above example                                                                                                                                                                                                                                                                                                                                                                , refers to the input parameter (whole string) to 'for'
 @rem Note: in a batch script we need to use %% instead of just % as per the docs.
 
 for %%f in ("%JAVA_HOME%") do set JAVA_HOME=%%~sf
@@ -177,17 +177,10 @@ set JAVA_VERSION_11=11
 
 if %JAVA_VERSION_INT_VALUE% lss %JAVA_VERSION_9% (
    echo "--- Pre-Java 9 detected ---"
-   echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
 ) else (
    echo "--- Java 9 or higher detected (version %JAVA_VERSION_INT_VALUE%) ---"
-   if %JAVA_VERSION_INT_VALUE% lss %JAVA_VERSION_11% (
-       set DEFAULT_JVM_OPTS=--illegal-access=warn --add-modules=java.xml.bind,java.activation %DEFAULT_JVM_OPTS%
-       echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '%DEFAULT_JVM_OPTS%'"
-   ) else (
-      echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
-      echo "Not using kill-switch or modules flags starting from this version of Java"
-   )
 )
+echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
 echo "--------------------------------------------------------------------------------------------------------------"
 
 @echo on

--- a/template-for-recording/record_screen_and_upload.bat
+++ b/template-for-recording/record_screen_and_upload.bat
@@ -171,15 +171,6 @@ for /f "tokens=1,2 delims=-" %%a in ("%JAVA_VERSION%") do (
 
 echo.
 echo JAVA_VERSION=%JAVA_VERSION_INT_VALUE%
-
-set JAVA_VERSION_9=9
-set JAVA_VERSION_11=11
-
-if %JAVA_VERSION_INT_VALUE% lss %JAVA_VERSION_9% (
-   echo "--- Pre-Java 9 detected ---"
-) else (
-   echo "--- Java 9 or higher detected (version %JAVA_VERSION_INT_VALUE%) ---"
-)
 echo "Using DEFAULT_JVM_OPTS variable with value '%DEFAULT_JVM_OPTS%'"
 echo "--------------------------------------------------------------------------------------------------------------"
 

--- a/template-for-recording/record_screen_and_upload.sh
+++ b/template-for-recording/record_screen_and_upload.sh
@@ -198,11 +198,7 @@ JAVA_VERSION=$($JAVACMD -version 2>&1 | grep '"9\|"10\|"11\|"12')
 # Only the first token is retained, and as per the above table,
 # it will always be empty or a numeric value between 9 and 12 (included)
 JAVA_VERSION_INT_VALUE=$(echo $JAVA_VERSION | grep -o '"[0-9]*' | tr -d '"')
-if [ -z "${JAVA_VERSION_INT_VALUE}" ]; then
-   echo "---> Pre-Java 9 detected <---"
-else
-   echo "---> Java 9 or higher detected (version $JAVA_VERSION_INT_VALUE) <---"
-fi
+echo "JAVA_VERSION=${JAVA_VERSION_INT_VALUE:-8}"
 echo "Using DEFAULT_JVM_OPTS variable with value '${DEFAULT_JVM_OPTS}'"
 echo "--------------------------------------------------------------------------------------------------------------"
 

--- a/template-for-recording/record_screen_and_upload.sh
+++ b/template-for-recording/record_screen_and_upload.sh
@@ -167,11 +167,11 @@ PARAM_CONFIG_FILE="--config ${APP_HOME}/config/credentials.config"
 PARAM_STORE_DIR="--store ${APP_HOME}/record/localstore"
 PARAM_SOURCECODE_DIR="--sourcecode ${APP_HOME}"
 
-# Look for tokens "9, "10, "11 or "12 in the Java version string, 
+# Look for tokens "9, "10, "11 or "12 in the Java version string,
 # if found, return the whole Java String, otherwise return empty string
 #
 # For e.g.
-#   --version command output    JAVA_VERSION   
+#   --version command output    JAVA_VERSION
 #   ========================   ==============
 #   java version "1.8.0_172"     <no output>
 #   java version "9.0.1"            "9
@@ -180,12 +180,12 @@ PARAM_SOURCECODE_DIR="--sourcecode ${APP_HOME}"
 #   java version "12-ea"            "12-ea
 JAVA_VERSION=$($JAVACMD -version 2>&1 | grep '"9\|"10\|"11\|"12')
 
-# Only include digits from value in JAVA_VERSION, 
-# If the above value contains non-numeric values, 
+# Only include digits from value in JAVA_VERSION,
+# If the above value contains non-numeric values,
 # only the digits before it are returned
 #
 # For e.g.
-#   JAVA_VERSION   JAVA_VERSION_INT_VALUE   
+#   JAVA_VERSION   JAVA_VERSION_INT_VALUE
 #   ============   ======================
 #    <no output>         <no output>
 #         9                  9
@@ -193,9 +193,9 @@ JAVA_VERSION=$($JAVACMD -version 2>&1 | grep '"9\|"10\|"11\|"12')
 #        11                  11
 #       12-ea                12
 #
-# The for loop below iterates through tokens, 
+# The for loop below iterates through tokens,
 # tokens are separated by the delimeter provided to 'delim'
-# Only the first token is retained, and as per the above table, 
+# Only the first token is retained, and as per the above table,
 # it will always be empty or a numeric value between 9 and 12 (included)
 JAVA_VERSION_INT_VALUE=$(echo $JAVA_VERSION | grep -o '"[0-9]*' | tr -d '"')
 if [ -z "${JAVA_VERSION_INT_VALUE}" ]; then
@@ -203,10 +203,15 @@ if [ -z "${JAVA_VERSION_INT_VALUE}" ]; then
    echo "Using DEFAULT_JVM_OPTS variable with value '${DEFAULT_JVM_OPTS}'"
 else
    echo "---> Java 9 or higher detected (version $JAVA_VERSION_INT_VALUE) <---"
-   DEFAULT_JVM_OPTS ="--illegal-access=warn  --add-modules=java.xml.bind,java.activation  ${DEFAULT_JVM_OPTS}"
-   echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '${DEFAULT_JVM_OPTS}'"
-   echo "--------------------------------------------------------------------------------------------------------------"
+   if [ ${JAVA_VERSION_INT_VALUE} -lt 11 ]; then
+       DEFAULT_JVM_OPTS="--illegal-access=warn  --add-modules=java.xml.bind,java.activation  ${DEFAULT_JVM_OPTS}"
+       echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '${DEFAULT_JVM_OPTS}'"
+   else
+       echo "Using DEFAULT_JVM_OPTS variable with value '${DEFAULT_JVM_OPTS}'"
+       echo "Not using kill-switch or modules flags starting from this version of Java"
+   fi
 fi
+echo "--------------------------------------------------------------------------------------------------------------"
 
 eval splitJvmOpts ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} ${RECORD_OPTS}
 exec "$JAVACMD" "${JVM_OPTS[@]}" -jar "$JARFILE" ${PARAM_CONFIG_FILE} ${PARAM_STORE_DIR} ${PARAM_SOURCECODE_DIR} "$@"

--- a/template-for-recording/record_screen_and_upload.sh
+++ b/template-for-recording/record_screen_and_upload.sh
@@ -200,17 +200,10 @@ JAVA_VERSION=$($JAVACMD -version 2>&1 | grep '"9\|"10\|"11\|"12')
 JAVA_VERSION_INT_VALUE=$(echo $JAVA_VERSION | grep -o '"[0-9]*' | tr -d '"')
 if [ -z "${JAVA_VERSION_INT_VALUE}" ]; then
    echo "---> Pre-Java 9 detected <---"
-   echo "Using DEFAULT_JVM_OPTS variable with value '${DEFAULT_JVM_OPTS}'"
 else
    echo "---> Java 9 or higher detected (version $JAVA_VERSION_INT_VALUE) <---"
-   if [ ${JAVA_VERSION_INT_VALUE} -lt 11 ]; then
-       DEFAULT_JVM_OPTS="--illegal-access=warn  --add-modules=java.xml.bind,java.activation  ${DEFAULT_JVM_OPTS}"
-       echo "Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '${DEFAULT_JVM_OPTS}'"
-   else
-       echo "Using DEFAULT_JVM_OPTS variable with value '${DEFAULT_JVM_OPTS}'"
-       echo "Not using kill-switch or modules flags starting from this version of Java"
-   fi
 fi
+echo "Using DEFAULT_JVM_OPTS variable with value '${DEFAULT_JVM_OPTS}'"
 echo "--------------------------------------------------------------------------------------------------------------"
 
 eval splitJvmOpts ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} ${RECORD_OPTS}

--- a/template-for-recording/record_screen_and_upload.sh
+++ b/template-for-recording/record_screen_and_upload.sh
@@ -178,7 +178,11 @@ PARAM_SOURCECODE_DIR="--sourcecode ${APP_HOME}"
 #   java version "10.0.1"           "10
 #   java version "11.0.2"           "11
 #   java version "12-ea"            "12-ea
-JAVA_VERSION=$($JAVACMD -version 2>&1 | grep '"9\|"10\|"11\|"12')
+JAVA_VERSION_STRING=$($JAVACMD -version 2>&1)
+echo ${JAVA_VERSION_STRING}
+JAVA_FULL_VERSION=$(echo ${JAVA_VERSION_STRING} | grep -o '\".*\"')
+echo JAVA_FULL_VERSION=${JAVA_FULL_VERSION}
+JAVA_VERSION=$(echo ${JAVA_FULL_VERSION}| grep '"9\|"10\|"11\|"12')
 
 # Only include digits from value in JAVA_VERSION,
 # If the above value contains non-numeric values,
@@ -195,7 +199,7 @@ JAVA_VERSION=$($JAVACMD -version 2>&1 | grep '"9\|"10\|"11\|"12')
 #
 # The for loop below iterates through tokens,
 # tokens are separated by the delimeter provided to 'delim'
-# Only the first token is retained, and as per the above table,
+# Only the first token is retained, and as pattern the above table,
 # it will always be empty or a numeric value between 9 and 12 (included)
 JAVA_VERSION_INT_VALUE=$(echo $JAVA_VERSION | grep -o '"[0-9]*' | tr -d '"')
 echo "JAVA_VERSION=${JAVA_VERSION_INT_VALUE:-8}"


### PR DESCRIPTION
Applied fix to record_screen_and_update Linux/MacOS and Windows scripts to overcome modules issue starting Java 11

Fix for issue https://github.com/julianghionoiu/record-and-upload/issues/7


**Test results**

_Linux_
_Java 8 - Linux_

```java
± ./record_screen_and_upload.sh
---> Pre-Java 9 detected <---
Using DEFAULT_JVM_OPTS variable with value ''
--------------------------------------------------------------------------------------------------------------
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @1583ms to org.eclipse.jetty.util.log.Slf4jLog
Java HotSpot(TM) 64-Bit Server VM warning: You have loaded library /tmp/humble2532518685419305331.tmp which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
INFO  [VideoRec]   - Open the input stream
INFO  [Upload]     - Sync local files with remote
INFO  [main]       - jetty-9.4.7.v20170914
INFO  [VideoRec]   - Start recording to "screencast_20181117T203434.mp4" at 16 fps with 4 screenshots/sec
INFO  [main]       - Started ServerConnector@654d8173{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @3524ms
INFO  [SourceRec]  - Start recording to "sourcecode_20181117T203434.srcs"
INFO  [Upload]     - Uploading file record/localstore/record-and-upload-20181117T203433.log
INFO  [Upload]     - Finished uploading file record/localstore/record-and-upload-20181117T203433.log
INFO  [Upload]     - Uploading file record/localstore/record-and-upload-20181117T202625.log
INFO  [main]       - ~~~~~~ Stopped ~~~~~~
```

_Java 9 - Linux_

```java
± go9
Switched to /usr/lib/jvm/jdk-9.0.1

satyasai at sai-XPS-15-9560 in ~/git-repos/BeFaster/tdl-runner-java on master!

± ./record_screen_and_upload.sh
---> Java 9 or higher detected (version 9) <---
Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '--illegal-access=warn  --add-modules=java.xml.bind,java.activation  '
--------------------------------------------------------------------------------------------------------------
WARNING: Illegal reflective access by Capsule (file:/home/satyasai/git-repos/BeFaster/tdl-runner-java/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
WARNING: Illegal reflective access by Capsule (file:/home/satyasai/git-repos/BeFaster/tdl-runner-java/record/record-and-upload-capsule.jar) to field java.lang.ProcessImpl.pid
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @1646ms to org.eclipse.jetty.util.log.Slf4jLog
Java HotSpot(TM) 64-Bit Server VM warning: You have loaded library /tmp/humble14984434904339375879.tmp which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
INFO  [VideoRec]   - Open the input stream
INFO  [Upload]     - Sync local files with remote
INFO  [main]       - jetty-9.4.7.v20170914
INFO  [main]       - Started ServerConnector@1976f537{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @3224ms
INFO  [SourceRec]  - Start recording to "sourcecode_20181117T203448.srcs"
INFO  [main]       - ~~~~~~ Stopped ~~~~~~
````

_Java 10 - Linux_

```java
± go10
Switched to /usr/lib/jvm/jdk-10.0.1

satyasai at sai-XPS-15-9560 in ~/git-repos/BeFaster/tdl-runner-java on master!

± ./record_screen_and_upload.sh
---> Java 9 or higher detected (version 10) <---
Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to '--illegal-access=warn  --add-modules=java.xml.bind,java.activation  '
--------------------------------------------------------------------------------------------------------------
WARNING: Illegal reflective access by Capsule (file:/home/satyasai/git-repos/BeFaster/tdl-runner-java/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
WARNING: Illegal reflective access by Capsule (file:/home/satyasai/git-repos/BeFaster/tdl-runner-java/record/record-and-upload-capsule.jar) to field java.lang.ProcessImpl.pid
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @1753ms to org.eclipse.jetty.util.log.Slf4jLog
Java HotSpot(TM) 64-Bit Server VM warning: You have loaded library /tmp/humble17437479209422854003.tmp which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
INFO  [VideoRec]   - Open the input stream
INFO  [Upload]     - Sync local files with remote
INFO  [main]       - jetty-9.4.7.v20170914
INFO  [main]       - Started ServerConnector@1976f537{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @3315ms
INFO  [SourceRec]  - Start recording to "sourcecode_20181117T211118.srcs"
INFO  [VideoRec]   - Start recording to "screencast_20181117T211118.mp4" at 16 fps with 4 screenshots/sec
INFO  [main]       - ~~~~~~ Stopped ~~~~~~
```

_Java 11 - Linux_

```java
± go11                         
Switched to /usr/lib/jvm/jdk-11

satyasai at sai-XPS-15-9560 in ~/git-repos/BeFaster/tdl-runner-java on master!

± ./record_screen_and_upload.sh
---> Java 9 or higher detected (version 11) <---
Using DEFAULT_JVM_OPTS variable with value ''
Not using kill-switch or modules flags starting from this version of Java
--------------------------------------------------------------------------------------------------------------
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by Capsule (file:/home/satyasai/git-repos/BeFaster/tdl-runner-java/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
WARNING: Please consider reporting this to the maintainers of Capsule
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @1350ms to org.eclipse.jetty.util.log.Slf4jLog
Java HotSpot(TM) 64-Bit Server VM warning: You have loaded library /tmp/humble15968755947215289552.tmp which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
INFO  [VideoRec]   - Open the input stream
INFO  [Upload]     - Sync local files with remote
INFO  [main]       - jetty-9.4.7.v20170914
INFO  [main]       - Started ServerConnector@5b84f14{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @2924ms
INFO  [SourceRec]  - Start recording to "sourcecode_20181117T203508.srcs"
INFO  [VideoRec]   - Start recording to "screencast_20181117T203508.mp4" at 16 fps with 4 screenshots/sec
INFO  [main]       - ~~~~~~ Stopped ~~~~~~
```

_Java 12 - Linux_

```java
± go12
Switched to /usr/lib/jvm/jdk-12

± ./record_screen_and_upload.sh
---> Java 9 or higher detected (version 12) <---
Using DEFAULT_JVM_OPTS variable with value ''
Not using kill-switch or modules flags starting from this version of Java
--------------------------------------------------------------------------------------------------------------
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by Capsule (file:/home/satyasai/git-repos/BeFaster/tdl-runner-java/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
WARNING: Please consider reporting this to the maintainers of Capsule
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @1408ms to org.eclipse.jetty.util.log.Slf4jLog
OpenJDK 64-Bit Server VM warning: You have loaded library /tmp/humble1574203657850087751.tmp which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
INFO  [VideoRec]   - Open the input stream
INFO  [Upload]     - Sync local files with remote
INFO  [main]       - jetty-9.4.7.v20170914
INFO  [main]       - Started ServerConnector@26f96b85{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @3738ms
INFO  [SourceRec]  - Start recording to "sourcecode_20181117T205033.srcs"
INFO  [Upload]     - Uploading file record/localstore/record-and-upload-20181117T205032.record/localstore/sourcecode_20181117T205033.srcs
INFO  [main]       - ~~~~~~ Stopped ~~~~~~
```

_Windows_
_Java 8 - Windows_

```java
JAVA_EXE=C:\PROGRA~1\Java\JDK18~1.0_1\bin\java.exe

D:\tdl-runner-java>for /F "tokens=3" %g in ('C:\PROGRA~1\Java\JDK18~1.0_1\bin\java.exe -version 2>&1 | findstr /i "version"') do (set JAVA_FULL_VERSION=%g )

D:\tdl-runner-java>(set JAVA_FULL_VERSION="1.8.0_181" )

JAVA_FULL_VERSION=1.8.0_181

JAVA_VERSION=8
"--- Pre-Java 9 detected ---"
"Using DEFAULT_JVM_OPTS variable with value ''"
"--------------------------------------------------------------------------------------------------------------"

D:\tdl-runner-java>"C:\PROGRA~1\Java\JDK18~1.0_1\bin\java.exe"    -jar "D:\tdl-runner-java\\record\record-and-upload-capsule.jar" --config D:\tdl-runner-java\\config\credentials.config --store D:\tdl-runner-java\\record\localstore --sourcecode D:\tdl-runner-java\
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @4374ms to org.eclipse.jetty.util.log.Slf4jLog
INFO  [VideoRec]   - Open the input stream
INFO  [Upload]     - Sync local files with remote
INFO  [main]       - jetty-9.4.7.v20170914
INFO  [SourceRec]  - Start recording to "sourcecode_20181117T211639.srcs"
INFO  [Metrics]    -  0 source capture,   0 ms/capture
INFO  [Metrics]    -  0 source capture,   0 ms/capture
INFO  [main]       - Started ServerConnector@7894f09b{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @45459ms
INFO  [VideoRec]   - Start recording to "screencast_20181117T211639.mp4" at 16 fps with 4 screenshots/sec
INFO  [Upload]     - Uploading file record/localstore/record-and-upload-20181117T211638.log
INFO  [Upload]     - Finished uploading file record/localstore/record-and-upload-20181117T211638.log
INFO  [Upload]     - Uploading file record/localstore/sourcecode_20181117T211639.srcs
INFO  [Upload]     - Finished uploading file record/localstore/sourcecode_20181117T211639.srcs
INFO  [main]       - ~~~~~~ Stopped ~~~~~~
```

_Java 9 - Windows_

```java
D:\tdl-runner-java>record_screen_and_upload.bat

Displaying operating system specific systeminfo...
OS Name:                   Microsoft Windows 10 Enterprise Evaluation
OS Version:                10.0.17134 N/A Build 17134
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
BIOS Version:              innotek GmbH VirtualBox, 01-Dec-06

JAVA_HOME=C:\PROGRA~1\Java\JDK-90~1.4

JAVA_EXE=C:\PROGRA~1\Java\JDK-90~1.4\bin\java.exe

D:\tdl-runner-java>for /F "tokens=3" %g in ('C:\PROGRA~1\Java\JDK-90~1.4\bin\java.exe -version 2>&1 | findstr /i "version"') do (set JAVA_FULL_VERSION=%g )

D:\tdl-runner-java>(set JAVA_FULL_VERSION="9.0.4" )

JAVA_FULL_VERSION=9.0.4

JAVA_VERSION=9
"--- Java 9 or higher detected (version 9) ---"
"Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to ''"
"--------------------------------------------------------------------------------------------------------------"

D:\tdl-runner-java>"C:\PROGRA~1\Java\JDK-90~1.4\bin\java.exe" --illegal-access=warn --add-modules=java.xml.bind,java.activation    -jar "D:\tdl-runner-java\\record\record-and-upload-capsule.jar" --config D:\tdl-runner-java\\config\credentials.config --store D:\tdl-runner-java\\record\localstore --sourcecode D:\tdl-runner-java\
WARNING: Illegal reflective access by Capsule (file:/D:/tdl-runner-java/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @1907ms to org.eclipse.jetty.util.log.Slf4jLog
```

_Java 10 - Windows_

```java
D:\tdl-runner-java>record_screen_and_upload.bat

Displaying operating system specific systeminfo...
OS Name:                   Microsoft Windows 10 Enterprise Evaluation
OS Version:                10.0.17134 N/A Build 17134
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
BIOS Version:              innotek GmbH VirtualBox, 01-Dec-06

JAVA_HOME=C:\PROGRA~1\Java\JRE-10~1.2

JAVA_EXE=C:\PROGRA~1\Java\JRE-10~1.2\bin\java.exe

D:\tdl-runner-java>for /F "tokens=3" %g in ('C:\PROGRA~1\Java\JRE-10~1.2\bin\java.exe -version 2>&1 | findstr /i "version"') do (set JAVA_FULL_VERSION=%g )

D:\tdl-runner-java>(set JAVA_FULL_VERSION="10.0.2" )

JAVA_FULL_VERSION=10.0.2

JAVA_VERSION=10
"--- Java 9 or higher detected (version 10) ---"
"Adding JVM args to the DEFAULT_JVM_OPTS variable, new value set to ''"
"--------------------------------------------------------------------------------------------------------------"

D:\tdl-runner-java>"C:\PROGRA~1\Java\JRE-10~1.2\bin\java.exe" --illegal-access=warn --add-modules=java.xml.bind,java.activation    -jar "D:\tdl-runner-java\\record\record-and-upload-capsule.jar" --config D:\tdl-runner-java\\config\credentials.config --store D:\tdl-runner-java\\record\localstore --sourcecode D:\tdl-runner-java\
WARNING: Illegal reflective access by Capsule (file:/D:/tdl-runner-java/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @2112ms to org.eclipse.jetty.util.log.Slf4jLog
INFO  [VideoRec]   - Open the input stream
INFO  [Upload]     - Sync local files with remote
INFO  [main]       - jetty-9.4.7.v20170914
INFO  [SourceRec]  - Start recording to "sourcecode_20181117T205635.srcs"
INFO  [Metrics]    -  0 source capture,   0 ms/capture
INFO  [main]       - Started ServerConnector@499683c4{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @11619ms
INFO  [VideoRec]   - Start recording to "screencast_20181117T205635.mp4" at 16 fps with 4 screenshots/sec
INFO  [Metrics]    - Recorded 0h00m00s,   0 frame, 0.00 MB |  0 source capture,   0 INFO  [main]       - Finished uploading file record/localstore/sourcecode_20181117T205635.srcs
INFO  [main]       - ~~~~~~ Stopped ~~~~~~
```

_Java 11 - Windows_

```java
D:\tdl-runner-java>record_screen_and_upload.bat

Displaying operating system specific systeminfo...
OS Name:                   Microsoft Windows 10 Enterprise Evaluation
OS Version:                10.0.17134 N/A Build 17134
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
BIOS Version:              innotek GmbH VirtualBox, 01-Dec-06

JAVA_HOME=C:\PROGRA~1\Java\JDK-11~1.1

JAVA_EXE=C:\PROGRA~1\Java\JDK-11~1.1\bin\java.exe

D:\tdl-runner-java>for /F "tokens=3" %g in ('C:\PROGRA~1\Java\JDK-11~1.1\bin\java.exe -version 2>&1 | findstr /i "version"') do (set JAVA_FULL_VERSION=%g )

D:\tdl-runner-java>(set JAVA_FULL_VERSION="11.0.1" )

JAVA_FULL_VERSION=11.0.1

JAVA_VERSION=11
"--- Java 9 or higher detected (version 11) ---"
"Using DEFAULT_JVM_OPTS variable with value ''"
"Not using kill-switch or modules flags starting from this version of Java"
"--------------------------------------------------------------------------------------------------------------"

D:\tdl-runner-java>"C:\PROGRA~1\Java\JDK-11~1.1\bin\java.exe"    -jar "D:\tdl-runner-java\\record\record-and-upload-capsule.jar" --config D:\tdl-runner-java\\config\credentials.config --store D:\tdl-runner-java\\record\localstore --sourcecode D:\tdl-runner-java\
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by Capsule (file:/D:/tdl-runner-java/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
WARNING: Please consider reporting this to the maintainers of Capsule
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @2100ms to org.eclipse.jetty.util.log.Slf4jLog
INFO  [VideoRec]   - Open the input stream
INFO  [Upload]     - Sync local files with remote
INFO  [main]       - jetty-9.4.7.v20170914
INFO  [VideoRec]   - Start recording to "screencast_20181117T211939.mp4" at 16 fps with 4 screenshots/sec
INFO  [main]       - Started ServerConnector@7c551ad4{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @8492ms
INFO  [main]       - ~~~~~~ Stopped ~~~~~~
```

_Java 12 - Windows_

```java
D:\tdl-runner-java>record_screen_and_upload.bat

Displaying operating system specific systeminfo...
OS Name:                   Microsoft Windows 10 Enterprise Evaluation
OS Version:                10.0.17134 N/A Build 17134
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
BIOS Version:              innotek GmbH VirtualBox, 01-Dec-06

JAVA_HOME=C:\PROGRA~1\Java\jdk-12

JAVA_EXE=C:\PROGRA~1\Java\jdk-12\bin\java.exe

D:\tdl-runner-java>for /F "tokens=3" %g in ('C:\PROGRA~1\Java\jdk-12\bin\java.exe -version 2>&1 | findstr /i "version"') do (set JAVA_FULL_VERSION=%g )

D:\tdl-runner-java>(set JAVA_FULL_VERSION="12-ea" )

JAVA_FULL_VERSION=12-ea

JAVA_VERSION=12
"--- Java 9 or higher detected (version 12) ---"
"Using DEFAULT_JVM_OPTS variable with value ''"
"Not using kill-switch or modules flags starting from this version of Java"
"--------------------------------------------------------------------------------------------------------------"

D:\tdl-runner-java>"C:\PROGRA~1\Java\jdk-12\bin\java.exe"    -jar "D:\tdl-runner-java\\record\record-and-upload-capsule.jar" --config D:\tdl-runner-java\\config\credentials.config --store D:\tdl-runner-java\\record\localstore --sourcecode D:\tdl-runner-java\
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by Capsule (file:/D:/tdl-runner-java/record/record-and-upload-capsule.jar) to field com.sun.jmx.mbeanserver.JmxMBeanServer.mbsInterceptor
WARNING: Please consider reporting this to the maintainers of Capsule
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
INFO  [main]       - Logging initialized @1645ms to org.eclipse.jetty.util.log.Slf4jLog
INFO  [VideoRec]   - Open the input stream
INFO  [VideoRec]   - Start recording to "screencast_20181117T204818.mp4" at 16 fps with 4 screenshots/sec
INFO  [Upload]     - Sync local files with remote
INFO  [Metrics]    - Recorded 0h00m00s,   0 frame, 0.00 MB
INFO  [main]       - jetty-9.4.7.v20170914
INFO  [main]       - Started ServerConnector@29a4f594{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @10115ms
INFO  [main]       - ~~~~~~ Stopped ~~~~~~
```