### PR TITLE
Enabled Jansi for Linux and MacOS via args passed through the CLI

### DIFF
--- a/generate-language-platform-bundles/record/record_screen_and_upload.sh
+++ b/generate-language-platform-bundles/record/record_screen_and_upload.sh
@@ -10,7 +10,15 @@ PARAM_SOURCECODE_DIR="${SCRIPT_CURRENT_DIR}"
 
 echo "Running using packaged JRE:"
 set -ex
-exec "$JAVA_BIN" -jar "$JAR_FILE" \
+
+#
+# Can also be resolved by using -Dlogback.configurationFile="./path/to/a/new/logback.xml"
+# instead of the below          -Dlogback.enableJansi="true"
+# to make logback use a different config xml file containing the new setting to switch on Jansi
+#
+exec "$JAVA_BIN"                    \
+  -Dlogback.enableJansi="true"      \
+  -jar "$JAR_FILE"                  \
   "--config" "${PARAM_CONFIG_FILE}" \
-  "--store" "${PARAM_STORE_DIR}" \
+  "--store" "${PARAM_STORE_DIR}"    \
   "--sourcecode" "${PARAM_SOURCECODE_DIR}" "$@"


### PR DESCRIPTION
Tested on Linux:
```
[snipped]
INFO  [main]       - Starting recording app
INFO  [main]       - Checking permissions
Java HotSpot(TM) 64-Bit Server VM warning: You have loaded library /tmp/humble6436127439036258000.tmp which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
INFO  [main]       - Logging initialized @1793ms to org.eclipse.jetty.util.log.Slf4jLog
INFO  [VideoRec]   - Open the input stream
INFO  [Upload]     - Sync local files with remote
INFO  [main]       - jetty-9.4.z-SNAPSHOT
INFO  [main]       - Started ServerConnector@3243b914{HTTP/1.1,[http/1.1]}{localhost:41375}
INFO  [main]       - Started @1854ms
INFO  [SourceRec]  - Start recording to "sourcecode_20190121T174711.srcs"
INFO  [VideoRec]   - Start recording to "screencast_20190121T174711.mp4" at 16 fps with 4 screenshots/sec
INFO  [Upload]     - Uploading file record/localstore/record-and-upload-20190121T174531.log
INFO  [Upload]     - Finished uploading file record/localstore/record-and-upload-20190121T174531.log
[snipped]
```
No Issue related to logger and Outputstream.

Should work the same for MacOS.